### PR TITLE
Add initial AuthService test project

### DIFF
--- a/AuthApi.Tests/AuthApi.Tests.csproj
+++ b/AuthApi.Tests/AuthApi.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.7.0" />
+    <PackageReference Include="Moq" Version="4.20.86" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AuthApi\AuthApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/AuthApi.Tests/Services/AuthServiceTests.cs
+++ b/AuthApi.Tests/Services/AuthServiceTests.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using Xunit;
+using Moq;
+using AuthApi.Services;
+using AuthApi.Domain.Dto.Auth;
+using AuthApi.Repository;
+using Microsoft.EntityFrameworkCore;
+using AuthApi.Domain.Identity;
+using Microsoft.AspNetCore.Identity;
+using AuthApi.Interfaces;
+
+namespace AuthApi.Tests.Services
+{
+    public class AuthServiceTests
+    {
+        [Fact]
+        public async Task Login_InvalidCredentials_ReturnsNullUser()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: "AuthServiceTests")
+                .Options;
+            var context = new ApplicationDbContext(options);
+
+            var testUser = new ApplicationUser { UserName = "testuser", Email = "t@example.com" };
+            context.Users.Add(testUser);
+            context.SaveChanges();
+
+            var userStore = new Mock<IUserStore<ApplicationUser>>();
+            var userManager = new Mock<UserManager<ApplicationUser>>(userStore.Object, null, null, null, null, null, null, null, null);
+            userManager.Setup(um => um.CheckPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(false);
+
+            var roleManager = new Mock<RoleManager<IdentityRole>>(Mock.Of<IRoleStore<IdentityRole>>(), null, null, null, null);
+            var jwtTokenGen = new Mock<IJwtTokenGenerator>();
+            var userService = new Mock<IUserService>();
+
+            var service = new AuthService(context, jwtTokenGen.Object, userService.Object, userManager.Object, roleManager.Object);
+
+            var request = new LoginRequestDto { UserName = "testuser", Password = "wrong" };
+
+            var result = await service.Login(request);
+
+            Assert.Null(result.User);
+        }
+    }
+}

--- a/MinimalAuthApi.sln
+++ b/MinimalAuthApi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthApi", "AuthApi\AuthApi.csproj", "{FB4A0608-5F45-48DC-BE2A-82AA41C914C4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthApi.Tests", "AuthApi.Tests\AuthApi.Tests.csproj", "{F3851EC5-4F28-45D1-9E91-B4CD7FDED90C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{30E7F864-3739-4178-994E-A684CC87059D}"
 	ProjectSection(SolutionItems) = preProject
 		AuthApi\docker-compose.yml = AuthApi\docker-compose.yml
@@ -19,8 +21,12 @@ Global
 		{FB4A0608-5F45-48DC-BE2A-82AA41C914C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FB4A0608-5F45-48DC-BE2A-82AA41C914C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB4A0608-5F45-48DC-BE2A-82AA41C914C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FB4A0608-5F45-48DC-BE2A-82AA41C914C4}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {FB4A0608-5F45-48DC-BE2A-82AA41C914C4}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F3851EC5-4F28-45D1-9E91-B4CD7FDED90C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F3851EC5-4F28-45D1-9E91-B4CD7FDED90C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F3851EC5-4F28-45D1-9E91-B4CD7FDED90C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F3851EC5-4F28-45D1-9E91-B4CD7FDED90C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add new AuthApi.Tests project targeting net8.0
- implement a unit test for invalid login in `AuthService`
- register test project in `MinimalAuthApi.sln`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684090282e6483238c5810817de24d7f